### PR TITLE
Migrate from master/slave lingo

### DIFF
--- a/server_py_files/core/objectify_xtsm.py
+++ b/server_py_files/core/objectify_xtsm.py
@@ -3409,12 +3409,12 @@ class Command_Library:
         a single stream of data - for example, for some devices (particularly FPGA-based) higher level
         functions require more complicated data inputs, despite the fact that their operation can be explained
         and controlled by a combination of simple elements - consider a "delay train clocker", which repeatedly counts a
-        certain number of its own clock cycles before issuing one or more clock signals to slaved devices : two
+        certain number of its own clock cycles before issuing one or more clock signals to subordinated devices : two
         pieces of information are required for each cycle - how many cycles to wait, and which devices to clock.
         This can be represented as a combination of two timing groups - one which has a single channel which is
         self-clocking (the "delaytrain"), and a second timing group which represents the clocking channels for the
-        slave devices.  Suppose the delaytrain clock cycle count is represented by a 32-bit integer, and there are
-        eight slave devices, requiring 8 bits to flag which channels should be triggered.  These two groups can
+        subordinate devices.  Suppose the delaytrain clock cycle count is represented by a 32-bit integer, and there are
+        eight subordinate devices, requiring 8 bits to flag which channels should be triggered.  These two groups can
         be entered in XTSM as if they are independent entities, and the timingstrings calculated as all others by
         standard parsing algorithms.  In a final step their timingstrings must be delivered to the hardware, which
         is most simply accomplished by combining the two fictional groups into a single group for the single piece

--- a/server_py_files/initializations/file_locations.py
+++ b/server_py_files/initializations/file_locations.py
@@ -49,7 +49,7 @@ file_locations={"raw_buffer_folders" : {69129942709L:"c:/wamp/www/raw_buffers/DB
 """
 
 """
-11603160389 = Rb_analysis/fqhe master?
+11603160389 = Rb_analysis/fqhe main?
 161342404561 = pfaffian
 264840316731455L: nate's laptop
 69129942709L: Vortex

--- a/server_py_files/initializations/server_initializations.py
+++ b/server_py_files/initializations/server_initializations.py
@@ -16,7 +16,7 @@ import uuid,sys
 #for mod in imports[uuid.getnode()]:
 #    setattr(sys.modules[__name__],mod,__import__(mod))
 
-fqhe_master_init="""
+fqhe_main_init="""
 """
 #self.dataContexts['default'].update({'Test_instrument':glab_instrument.Glab_Instrument(params={'server':self,'create_example_pollcallback':True})})
 
@@ -40,6 +40,6 @@ print 'here is pfaffians init script - im in server_initializations.py'
 # the dictionary below has an entry for each machine, with a script
 # that should be executed at the time the server is initialized
 initializations={264840316731455L: natural_init, 
-                 11603160389L: fqhe_master_init,
+                 11603160389L: fqhe_main_init,
                  161342404561L: pfaffian_init }
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.